### PR TITLE
Fixing field type generation

### DIFF
--- a/src/main/resources/templates/GraphQLizerClassTemplate.ftl
+++ b/src/main/resources/templates/GraphQLizerClassTemplate.ftl
@@ -4,30 +4,26 @@ ${field.imports()}
 ${import}
 
 public class ${field.type} implements GraphQLizer {
-<#list field.properties as p>
-    <#if p.field.isList()>
-    private ${p.field.listField.type} ${p.name};
-    <#else>
-    private ${p.field.type} ${p.name};
-    </#if>
-</#list>
 
 <#list field.properties as p>
     <#if p.field.isObject() || field.isInputObject()>
-    public ${field.type} include${p.name[0]?upper_case}${p.name?substring(1)}(${p.field.type} ${p.name}) {
+        private ${p.field.type} ${p.name};
+        public ${field.type} include${p.name[0]?upper_case}${p.name?substring(1)}(${p.field.type} ${p.name}) {
         this.${p.name} = ${p.name};
         return this;
-    }
+        }
     <#elseif p.field.isList()>
-    public ${field.type} include${p.name[0]?upper_case}${p.name?substring(1)}(${p.field.listField.type} ${p.name}) {
+        private ${p.field.listField.type} ${p.name};
+        public ${field.type} include${p.name[0]?upper_case}${p.name?substring(1)}(${p.field.listField.type} ${p.name}) {
         this.${p.name} = ${p.name};
         return this;
-    }
+        }
     <#else>
-    public ${field.type} include${p.name[0]?upper_case}${p.name?substring(1)}() {
+        private ${p.field.type} ${p.name};
+        public ${field.type} include${p.name[0]?upper_case}${p.name?substring(1)}() {
         ${p.field.defaultValue("this.${p.name}")};
         return this;
-    }
+        }
     </#if>
 </#list>
     private ${field.type}() {


### PR DESCRIPTION
The fields with collection type list were not being recognised as collection type in the variable declaration, but is being recognised as collection in the param of the include* methods that were generated. So as quick fix moved the declaration of the fields inside the loop where the include* methods were generated.